### PR TITLE
Add missing subnet_id to specs to fix EC2 always using default VPC

### DIFF
--- a/src/mist/api/tasks.py
+++ b/src/mist/api/tasks.py
@@ -637,6 +637,7 @@ def create_machine_async(
              'post_script_params': post_script_params,
              'azure_port_bindings': azure_port_bindings,
              'associate_floating_ip': associate_floating_ip,
+             'subnet_id': subnet_id,
              'cloud_init': cloud_init,
              'disk_size': disk_size,
              'disk_path': disk_path,


### PR DESCRIPTION
This PR fixes an issue where if you have multiple VPCs for EC2, when you create a machine via the GUI, the default VPC is always used - no matter which one you choose. This is because the subnet_id is missing from the specs passed onto create_machine.