### PR TITLE
Added ability to modify elasticsearch, mongodb and rabbitmq addresses

### DIFF
--- a/bin/wait-all
+++ b/bin/wait-all
@@ -48,6 +48,6 @@ exec bin/wait-for \
     -t $TIMEOUT \
     $(if [ -n "$QUIET" ]; then echo "-q"; fi) \
     $(if [ -n "$CMD" ]; then echo -c "$CMD"; fi) \
-    elasticsearch:9200 \
-    mongodb:27017 \
-    rabbitmq:5672
+    ${ELASTICSEARCH_HOST:-elasticsearch}:${ELASTICSEARCH_PORT:-9200} \
+    ${MONGODB_HOST:-mongodb}:${MONGODB_PORT:-27017} \
+    ${RABBITMQ_HOST:-rabbitmq}:${RABBITMQ_PORT:-5672}


### PR DESCRIPTION
Allow set non-standard addresses for elasticsearch, mongodb and rabbitmq via env vars.